### PR TITLE
Fix mixed content warning for the *SoC index pages

### DIFF
--- a/gsoc/2016/index.md
+++ b/gsoc/2016/index.md
@@ -6,7 +6,7 @@ Since then, the project has grown with the aim changed to provide a complete fra
 
 Radare2 is composed of an hexadecimal editor as central point, with several assemblers/disassemblers, code analysis capabilities, scripting features, visualization of code and data through graphs and other means, a visual mode, easy unix integration, a diff engine, a shellcode compiler, and much more.
 
-![graph](http://radare.today/images/graph.png)
+![graph](https://radare.today/images/graph.png)
 
 # Previous Years
 

--- a/gsoc/2017/index.md
+++ b/gsoc/2017/index.md
@@ -6,7 +6,7 @@ Since then, the project has grown with the aim changed to provide a complete fra
 
 Radare2 is composed of an hexadecimal editor as central point, with several assemblers/disassemblers, code analysis capabilities, scripting features, visualization of code and data through graphs and other means, a visual mode, easy unix integration, a diff engine, a shellcode compiler, and much more.
 
-![graph](http://radare.today/images/graph.png)
+![graph](https://radare.today/images/graph.png)
 
 # Previous Years
 

--- a/gsoc/2018/index.md
+++ b/gsoc/2018/index.md
@@ -6,7 +6,7 @@ Since then, the project has grown with the aim changed to provide a complete fra
 
 Radare2 is composed of an hexadecimal editor as central point, with several assemblers/disassemblers, code analysis capabilities, scripting features, visualization of code and data through graphs and other means, a visual mode, easy unix integration, a diff engine, a shellcode compiler, and much more.
 
-![graph](http://radare.today/images/graph.png)
+![graph](https://radare.today/images/graph.png)
 
 # Previous Years
 

--- a/gsoc/2019/index.md
+++ b/gsoc/2019/index.md
@@ -6,7 +6,7 @@ Since then, the project has grown with the new aim of providing a complete frame
 
 Radare2 is composed of an hexadecimal editor as central point, with several assemblers/disassemblers, code analysis capabilities, scripting features, visualization of code and data through graphs and other means, a visual mode, easy unix integration, a diff engine, a shellcode compiler, and much more.
 
-![graph](http://radare.today/images/graph.png)
+![graph](https://radare.today/images/graph.png)
 
 # Previous Years
 

--- a/rsoc/2016/index.md
+++ b/rsoc/2016/index.md
@@ -6,7 +6,7 @@ Since then, the project has grown with the aim changed to provide a complete fra
 
 Radare2 is composed of an hexadecimal editor as central point, with several assemblers/disassemblers, code analysis capabilities, scripting features, visualization of code and data through graphs and other means, a visual mode, easy unix integration, a diff engine, a shellcode compiler, and much more.
 
-![graph](http://radare.today/images/graph.png)
+![graph](https://radare.today/images/graph.png)
 
 # Previous Years
 

--- a/rsoc/2017/index.md
+++ b/rsoc/2017/index.md
@@ -6,7 +6,7 @@ Since then, the project has grown with the aim changed to provide a complete fra
 
 Radare2 is composed of an hexadecimal editor as central point, with several assemblers/disassemblers, code analysis capabilities, scripting features, visualization of code and data through graphs and other means, a visual mode, easy unix integration, a diff engine, a shellcode compiler, and much more.
 
-![graph](http://radare.today/images/graph.png)
+![graph](https://radare.today/images/graph.png)
 
 # Previous Years
 


### PR DESCRIPTION
I would've converted the other links to https as well, but
http://rada.re/ has different redirect patterns than https://rada.re/,
the HTTP site redirects to https://www.radare.com/, the HTTPS site
displays content directly.

https://support.mozilla.org/en-US/kb/mixed-content-blocking-firefox