### PR TITLE
Remove CFP website since it's not up to date yer

### DIFF
--- a/con/2020/index.html
+++ b/con/2020/index.html
@@ -33,8 +33,8 @@ Su Mo Tu We Th Fr Sa
 <b>r2con$ cat /pub/cfp</b>
 The CFP for r2con2020 is not yet open but if you are
 willing to apply, or you want some feedback about your
-proposals feel free to contact us via <a href="mailto:r2con@radare.org">r2con@radare.org</a>
-or directly in <a href="http://cfp.radare.org">cfp.radare.org</a>
+proposals feel free to contact us via <a href="mailto:r2con@radare.org">r2con@radare.org</a>. Our CFP form and website will be published soon.
+
 
 
 --r2con.org


### PR DESCRIPTION

**Detailed description**

Since the CFP website is not up yet, the link should not be there.

