### PR TITLE
Fix link to the Radare2 book.

### DIFF
--- a/n/radare2.html
+++ b/n/radare2.html
@@ -211,7 +211,7 @@ One of the main benefits of using r2frida instead of frida is, despite not depen
 
 Join the <a href="https://t.me/radare">Telegram / IRC</a> channels and feel free to ask anything.
 
-In addition you can read <a href="https://radareorg.github.io/radare2book/index.html">The Book</a>
+In addition you can read <a href="https://book.rada.re">The Book</a>
 
 but everything in r2 is self-documented (just append the '?' char) or read the manpages/-h:
 </p>


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

While I was learning r2, I noticed there was an incorrect link to The Book. This updates it to the link used in the rest of the site.